### PR TITLE
Fix bad_domains config ignored on nil DMARC result

### DIFF
--- a/lib/dmilter.rb
+++ b/lib/dmilter.rb
@@ -59,6 +59,8 @@ class DmarcFilter
   end
 
   def dmarc?(domain)
+    return true if OPTS["other_bad_domains"].include?(domain)
+
     tries = 0
     begin
       r = DMARC::Record.query(domain)
@@ -79,8 +81,7 @@ class DmarcFilter
       r.aspf == :s ||
       r.adkim == :s ||
       r.sp == :reject ||
-      r.sp == :quarantine ||
-      OPTS["other_bad_domains"].include?(domain)
+      r.sp == :quarantine
   end
 end
 

--- a/test/milter_test.rb
+++ b/test/milter_test.rb
@@ -30,8 +30,7 @@ class DmarcFilterTest < Minitest::Test
   end
 
   def test_dmarc_bad_domains
-    ok_dmarc_record = DMARC::Record.new({ v: :DMARC1, p: nil, rua: nil })
-    DMARC::Record.expects(:query).with("some-domain-that-acts-like-dmarc.tld").returns(ok_dmarc_record)
+    DMARC::Record.expects(:query).never
 
     assert @dmf.dmarc?("some-domain-that-acts-like-dmarc.tld")
   end


### PR DESCRIPTION
We'd return false if the DMARC record was nil, breaking hard-coded bad domains in this case