### PR TITLE
Work around missing subdomain sp=reject logic in dmarc gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org".freeze
 gem "dmarc"
 gem "mail"
 gem "milter"
+gem "public_suffix"
 gem "resolv-replace"
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,7 @@ GEM
       ast (~> 2.4.1)
       racc
     parslet (2.0.0)
+    public_suffix (6.0.1)
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
@@ -79,6 +80,7 @@ DEPENDENCIES
   milter
   minitest
   mocha
+  public_suffix
   rake
   resolv-replace
   rubocop

--- a/test/milter_test.rb
+++ b/test/milter_test.rb
@@ -89,4 +89,15 @@ class DmarcFilterTest < Minitest::Test
 
     assert_equal @our_address, dmf.eval("invalid_fromline@some-domain.tld>")
   end
+
+  # Cover the case of a subdomain that isn't rejecting but the parent domain is (via sp=reject)
+  # This should be modified once https://github.com/trailofbits/dmarc/issues/26 is resolved
+  def test_dmarc_found_on_parent_domain_but_not_subdomain
+    hostname = "sub.outbound.some-other-domain.tld"
+    bad_dmarc_record1 = DMARC::Record.new({ v: :DMARC1, sp: :reject })
+    DMARC::Record.expects(:query).with(hostname).returns(nil)
+    DMARC::Record.expects(:query).with("some-other-domain.tld").returns(bad_dmarc_record1)
+
+    assert @dmf.eval("Jane Doe <jdoe@sub.outbound.some-other-domain.tld>")
+  end
 end


### PR DESCRIPTION
Upstream dmarc gem isn't doing parent/subdomain checking (sp=reject) so add workaround by checking the parent domain manually.